### PR TITLE
better error message when failing to retrieve storage class configs

### DIFF
--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -223,7 +223,7 @@ func (p *freenasProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	// get config
 	config, err := p.GetConfig(*options.PVC.Spec.StorageClassName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed getting storage class configuration for %v: %v", *options.PVC.Spec.StorageClassName, err.Error())
 	}
 	//glog.Infof("%+v\n", config)
 


### PR DESCRIPTION
The error message when the storage class on a persistent volume claim is incorrect / undefined is very opaque, ie:
```
E0719 20:45:59.459326       1 goroutinemap.go:153] operation for "provision-monitoring/prometheus-k8s-db-prometheus-k8s-0[6b0881c1-8b94-11e8-b452-005056961257]" failed with: recovered from panic "runtime error: invalid memory address or nil pointer dereference". (err=<nil>) Call stack:
```
This change would allow someone to potentially know that the error comes from their storage class definition without digging into the code.

Also, I have been unable to satisfy build dependencies for this project, despite `glide install` successfully returning, so I have been unable to make sure this compiles. 

Perhaps someone has insight into this as well?
```
$ make
mkdir -p bin
env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -o bin/freenas-provisioner .
../../../go/src/github.com/nmaupu/freenas-provisioner/provisioner/provisioner.go:9:2: cannot find package "k8s.io/api/v1" in any of:
	/usr/lib/go/src/k8s.io/api/v1 (from $GOROOT)
	/home/mamiller/go/src/k8s.io/api/v1 (from $GOPATH)
	/home/mamiller/projects/orc/src/k8s.io/api/v1
Makefile:30: recipe for target 'build' failed
make: *** [build] Error 1
```
I've tried with a clean go v.1.8.3 install to no prevail. 
Thanks