### PR TITLE
resolve 120 char limit for NFS share comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ make fmt
  * https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/volume-provisioning.md
  * https://kubernetes.io/docs/concepts/storage/storage-classes/
  * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#-strong-api-overview-strong-
+ * https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md
+ * https://github.com/kubernetes-csi/drivers/tree/master/pkg
 
 ## TODO
  * volume resizing - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/grow-volume-size.md

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -311,7 +311,7 @@ func (p *freenasProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		MapallGroup:  config.ShareMapallGroup,
 		MaprootUser:  config.ShareMaprootUser,
 		MaprootGroup: config.ShareMaprootGroup,
-		Comment:      fmt.Sprintf("freenas-provisioner (%s): %s", p.Identifier, dsPath),
+		Comment:      fmt.Sprintf("freenas-provisioner (%s): %s", p.Identifier, dsPath)[0:120],
 	}
 
 	glog.Infof("Creating dataset: \"%s\", NFS share: \"%s\"", ds.Name, path)


### PR DESCRIPTION
If you'd like to tag an bump image and deployment that would be great.

```{"nfs_comment": ["Ensure this value has at most 120 characters (it has 125)."]}```