### PR TITLE
set accept and content-type headers

### DIFF
--- a/freenas/server.go
+++ b/freenas/server.go
@@ -45,5 +45,5 @@ func (s *FreenasServer) getSlingConnection() *sling.Sling {
 	}
 
 	httpClient := &http.Client{Transport: tr}
-	return sling.New().Client(httpClient).Base(s.url).SetBasicAuth(s.Username, s.Password)
+	return sling.New().Client(httpClient).Base(s.url).SetBasicAuth(s.Username, s.Password).Set("Accept", "application/json").Set("Content-Type", "application/json")
 }


### PR DESCRIPTION
Staring somewhere in `11.2-U6 or U7` the FreeNAS API started requiring this for certain calls. The current endpoints used by the provisioner appear to be fine (which I find odd) but may be good to get ahead of it.

I already added this to my csi driver and the iscsi go project.

Thanks!