### PR TITLE
warn about datasets smaller than 1Gi

### DIFF
--- a/deploy/test-claim.yaml
+++ b/deploy/test-claim.yaml
@@ -9,4 +9,6 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 1Mi
+      # Apparently, around feb20, changes have been incorporated into FreeNAS
+      # disallowing quotas smaller than 1Gi, github.com/freenas/webui/pull/3613
+      storage: 1Gi


### PR DESCRIPTION
Apparently, around February 2020, it is not possible to create datasets
smaller than 1Gi in FreeNAS. This leads to errors such as
`message: {"refquota":["Should be greater or equal than 1073741824 or
Should be 0"]}, status: 400`, for which it is hard to find the root
cause.